### PR TITLE
Add/bridge drop noise

### DIFF
--- a/Assets/Audio/wooden thud.mp3
+++ b/Assets/Audio/wooden thud.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6c52b38493d1e26796444c50207eea3f31378193e2a2280d3686df35f3b63ea
+size 30301

--- a/Assets/Audio/wooden thud.mp3.meta
+++ b/Assets/Audio/wooden thud.mp3.meta
@@ -1,0 +1,22 @@
+fileFormatVersion: 2
+guid: 1ca0270ba072e48498cbebefe84187ce
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 6
+  defaultSettings:
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  preloadAudioData: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Bridge.prefab
+++ b/Assets/Prefabs/Bridge.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 8987490749276889326}
   - component: {fileID: 5739524043030434251}
   - component: {fileID: -5761882593040802925}
+  - component: {fileID: 2328876693914615575}
   m_Layer: 0
   m_Name: Bridge
   m_TagString: Bridge
@@ -122,3 +123,99 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 14.308165, y: 7.7467875}
   m_EdgeRadius: 0
+--- !u!82 &2328876693914615575
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8855985278181753037}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 8300000, guid: 1ca0270ba072e48498cbebefe84187ce, type: 3}
+  m_PlayOnAwake: 0
+  m_Volume: 0.2
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4

--- a/Assets/Scripts/Props/Bridge.cs
+++ b/Assets/Scripts/Props/Bridge.cs
@@ -1,12 +1,27 @@
+using UnityEngine;
+
 namespace Props
 {
     public class Bridge : PlayerDraggable
     {
+        private AudioSource _audioSource;
+
         protected override void Start()
         {
+            _audioSource = GetComponent<AudioSource>();
             base.Start();
             // Left just for LD speed.
         }
-        
+
+        protected override void OnMouseUp()
+        {
+            // Play wooden thud
+            if (!_audioSource.isPlaying)
+            {
+                _audioSource.Play();
+            }
+
+            base.OnMouseUp();
+        }
     }
 }


### PR DESCRIPTION
Simple PR,  adds a sound that plays when you drop the bridge. Might need better checks later, but currently can only be played if not already playing to prevent weird sound errors.