### PR TITLE
Finish highscore persistence

### DIFF
--- a/Assets/Scripts/Controllers/StatsController.cs
+++ b/Assets/Scripts/Controllers/StatsController.cs
@@ -27,6 +27,11 @@ namespace Controllers
             RawTimes.Add(PlayerPrefs.GetFloat("BestTime3"));
             RawTimes.Add(PlayerPrefs.GetFloat("BestTime4"));
             RawTimes.Add(PlayerPrefs.GetFloat("BestTime5"));
+            RawTimes.Sort();
+            RawTimes.Reverse();
+            // Only keep the 5 best times.
+            RawTimes = RawTimes.GetRange(0, 5);
+
             FormattedTimes = new List<string>();
             RepopulateFormattedTimes();
 
@@ -58,8 +63,14 @@ namespace Controllers
 
         public void onGameEnd()
         {
+            if (_timerRunning) {
             _timerRunning = false;
             RawTimes.Add(time);
+            // Sort by largest-first.
+            RawTimes.Sort();
+            RawTimes.Reverse();
+            // Only keep the 5 best times.
+            RawTimes = RawTimes.GetRange(0, 5);
             SaveBestTimes();
             RepopulateFormattedTimes();
 
@@ -75,9 +86,6 @@ namespace Controllers
 
         private void SaveBestTimes()
         {
-            // Only keep the 5 best times.
-            RawTimes.Sort();
-            RawTimes = RawTimes.GetRange(0, 5);
             for (int i = 0; i < 5; i++) {
                 PlayerPrefs.SetFloat("BestTime"+(i+1), RawTimes[i]);
             }
@@ -86,12 +94,11 @@ namespace Controllers
         private void RepopulateFormattedTimes()
         {
             // Only keep the 5 best times.
-            RawTimes.Sort();
             RawTimes = RawTimes.GetRange(0, 5);
             // Repopulate formatted times.
             FormattedTimes.Clear();
-            foreach (float score in RawTimes) {
-                FormattedTimes.Add(FormatTime(time));
+            for (int i = 0; i < 5; i++) {
+                FormattedTimes.Add(FormatTime(RawTimes[i]));
             }            
         }
 

--- a/Assets/Scripts/Controllers/StatsController.cs
+++ b/Assets/Scripts/Controllers/StatsController.cs
@@ -64,24 +64,25 @@ namespace Controllers
         public void onGameEnd()
         {
             if (_timerRunning) {
-            _timerRunning = false;
-            RawTimes.Add(time);
-            // Sort by largest-first.
-            RawTimes.Sort();
-            RawTimes.Reverse();
-            // Only keep the 5 best times.
-            RawTimes = RawTimes.GetRange(0, 5);
-            SaveBestTimes();
-            RepopulateFormattedTimes();
+                _timerRunning = false;
+                RawTimes.Add(time);
+                // Sort by largest-first.
+                RawTimes.Sort();
+                RawTimes.Reverse();
+                // Only keep the 5 best times.
+                RawTimes = RawTimes.GetRange(0, 5);
+                SaveBestTimes();
+                RepopulateFormattedTimes();
 
-            deaths++;
+                deaths++;
 
-            PlayerPrefs.SetInt("TotalDeaths", deaths);
-            PlayerPrefs.SetInt("TotalFoodsEaten", foodsEaten);
-            PlayerPrefs.SetInt("TotalObjectsSmashed", objectsSmashed);
-            PlayerPrefs.SetInt("TotalBridgesCrossed", bridgesCrossed);
-            PlayerPrefs.SetInt("TotalBouldersBumped", bouldersBumped);
-            PlayerPrefs.Save();
+                PlayerPrefs.SetInt("TotalDeaths", deaths);
+                PlayerPrefs.SetInt("TotalFoodsEaten", foodsEaten);
+                PlayerPrefs.SetInt("TotalObjectsSmashed", objectsSmashed);
+                PlayerPrefs.SetInt("TotalBridgesCrossed", bridgesCrossed);
+                PlayerPrefs.SetInt("TotalBouldersBumped", bouldersBumped);
+                PlayerPrefs.Save();
+            }
         }
 
         private void SaveBestTimes()
@@ -125,6 +126,7 @@ namespace Controllers
             bridgesCrossed++;
         }
 
+        // TODO Needs to be linked-up.
         public void IncrementBouldersBumped()
         {
             bouldersBumped++;

--- a/Assets/Scripts/Controllers/StatsController.cs
+++ b/Assets/Scripts/Controllers/StatsController.cs
@@ -63,6 +63,8 @@ namespace Controllers
             SaveBestTimes();
             RepopulateFormattedTimes();
 
+            deaths++;
+
             PlayerPrefs.SetInt("TotalDeaths", deaths);
             PlayerPrefs.SetInt("TotalFoodsEaten", foodsEaten);
             PlayerPrefs.SetInt("TotalObjectsSmashed", objectsSmashed);


### PR DESCRIPTION
* Fixed bug where higscores were sorted smallest-to-largest and thus omitting all real highscores.
* Fixed bug where only the most-recent highscore was being displayed.