### PR TITLE
fix/objects persist on ground destroy

### DIFF
--- a/Assets/Scripts/Ground/Ground.cs
+++ b/Assets/Scripts/Ground/Ground.cs
@@ -1,4 +1,5 @@
 using Controllers;
+using Props;
 using UnityEngine;
 using Random = UnityEngine.Random;
 
@@ -33,6 +34,14 @@ namespace Ground
 
         private void Die()
         {
+            PlayerDraggable[] playerDraggableArray = gameObject.GetComponentsInChildren<PlayerDraggable>();
+            Transform obstacleController = FindObjectOfType<ObstacleController>().transform;
+            foreach (PlayerDraggable playerDraggable in playerDraggableArray)
+            {
+                playerDraggable.gameObject.AddComponent<GroundMovement>();
+                playerDraggable.gameObject.transform.parent = obstacleController;
+                
+            }
             Destroy(gameObject);
         }
     }

--- a/Assets/Scripts/Ground/GroundMovement.cs
+++ b/Assets/Scripts/Ground/GroundMovement.cs
@@ -1,23 +1,27 @@
 using Controllers;
+using Props;
 using UnityEngine;
 
 namespace Ground
 {
     public class GroundMovement : MonoBehaviour
     {
-        private BoxCollider2D _boxCollider;
+        private Collider2D _Collider;
         private Ground _ground;
         private WorldController _worldController;
 
         // Start is called before the first frame update
         private void Start()
         {
-            // Activate the ground movement here
-            _ground = FindObjectOfType<Ground>();
-            _worldController = _ground.GetWorldCollider();
+            if (!gameObject.GetComponent<PlayerDraggable>())
+            {
+                // Activate the ground movement here
+                _ground = FindObjectOfType<Ground>();
+                _worldController = _ground.GetWorldCollider();
+            }
 
-            _boxCollider = GetComponent<BoxCollider2D>();
-            _boxCollider.enabled = false;
+            _Collider = GetComponent<Collider2D>();
+            _Collider.enabled = false;
         }
 
         // Update is called once per frame

--- a/Assets/Scripts/Props/PlayerDraggable.cs
+++ b/Assets/Scripts/Props/PlayerDraggable.cs
@@ -86,6 +86,8 @@ namespace Props
         // Update is called once per frame
         protected override void Update()
         {
+            if (transform.position.x < 0)
+                Destroy(gameObject);
             // If the player is clicking on the object.
             if (IsPlayerInteracting)
             {
@@ -101,7 +103,6 @@ namespace Props
             {
                 if (_isFallingFromMountain && getCrossProduct("mountain") < 0)
                 {
-                    
                     _isFallingFromMountain = false;
                     Destroy(gameObject.GetComponent<Rigidbody2D>());
                 }


### PR DESCRIPTION
Objects no longer get deleted when ground destroys, re-parents to ObjectController.
If object leaves screen, then delete.