### PR TITLE
potential fix implemented for flying dodo on replay.

### DIFF
--- a/Assets/Scripts/Dodo.cs
+++ b/Assets/Scripts/Dodo.cs
@@ -483,12 +483,14 @@ public class Dodo : MonoBehaviour
         _anim.SetBool(DeadDodo, false);
         transform.position = _originTransform.position;
         _isEating = false;
+        _isOnBridge = false;
         _isInMud = false;
         _currentDodoAcceleration = 0f;
         _currentBehaviour = 1;
         _behaviourTimer = 0f;
         _isGameRunning = true;
-        
+        dodoSpeed = dodoDefaultSpeed;
+
     }
 
     public void onGameEnd()


### PR DESCRIPTION
RELATED BUG: Restarting a game doesn't reset everything correctly (somehow)?? sometimes it puts you in the sky right after replay.

Tested in 4 runs and could not replicate. Leave branch open post merge in case bug returns.